### PR TITLE
fixed aodv-trace errors

### DIFF
--- a/main/aodv/aodv-tracer.cc
+++ b/main/aodv/aodv-tracer.cc
@@ -64,7 +64,7 @@ void MrclAodvTracer::format(Packet *p, SAP *sap)
 				snprintf(temp, sizeof(temp), "%d", rq->rq_src[i+sizeof(int)]);
 			else
 				snprintf(temp, sizeof(temp), "%d.", rq->rq_src[i+sizeof(int)]);
-			strncat(saddr, temp, sizeof(saddr));
+			strncat(saddr, temp, sizeof(saddr)-1);
 		}
 		strcat(saddr,"\0");
 
@@ -78,7 +78,7 @@ void MrclAodvTracer::format(Packet *p, SAP *sap)
 					snprintf(temp, sizeof(temp), "%d", rq->rq_dst[i+sizeof(int)]);
 				else
 					snprintf(temp, sizeof(temp), "%d.", rq->rq_dst[i+sizeof(int)]);
-				strncat(daddr, temp, sizeof(daddr));
+				strncat(daddr, temp, sizeof(daddr)-1);
 			}
 		}
 		strcat(daddr,"\0");
@@ -95,7 +95,7 @@ void MrclAodvTracer::format(Packet *p, SAP *sap)
 				snprintf(temp, sizeof(temp), "%d", rp->rp_src[i+sizeof(int)]);
 			else
 				snprintf(temp, sizeof(temp), "%d.", rp->rp_src[i+sizeof(int)]);
-			strncat(saddr,temp, sizeof(saddr));
+			strncat(saddr,temp, sizeof(saddr)-1);
 		}
 		strcat(saddr,"\0");
 
@@ -109,7 +109,7 @@ void MrclAodvTracer::format(Packet *p, SAP *sap)
 					snprintf(temp, sizeof(temp), "%d", rp->rp_dst[i+sizeof(int)]);
 				else
 					snprintf(temp, sizeof(temp), "%d.", rp->rp_dst[i+sizeof(int)]);
-				strncat(daddr,temp, sizeof(daddr));
+				strncat(daddr,temp, sizeof(daddr)-1);
 			}
 		}
 		strcat(daddr,"\0");


### PR DESCRIPTION
Fixed the following errors when trying to install nsmiracle on a raspberry Pi 4 with Raspberry Pi Os 64 bit.
```aodv-tracer.cc: In member function 'virtual void MrclAodvTracer::format(Packet*, SAP*)':
aodv-tracer.cc:67:32: error: 'char* strncat(char*, const char*, size_t)' specified bound 288 equals destination size [-Werror=stringop-overflow=]
   67 |                         strncat(saddr, temp, sizeof(saddr));
      |                         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
aodv-tracer.cc:81:40: error: 'char* strncat(char*, const char*, size_t)' specified bound 288 equals destination size [-Werror=stringop-overflow=]
   81 |                                 strncat(daddr, temp, sizeof(daddr));
      |                                 ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
aodv-tracer.cc:98:32: error: 'char* strncat(char*, const char*, size_t)' specified bound 288 equals destination size [-Werror=stringop-overflow=]
   98 |                         strncat(saddr,temp, sizeof(saddr));
      |                         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
aodv-tracer.cc:112:40: error: 'char* strncat(char*, const char*, size_t)' specified bound
288 equals destination size [-Werror=stringop-overflow=]
  112 |                                 strncat(daddr,temp, sizeof(daddr));
      |                                 ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
```