### PR TITLE
fixed all warnings, added no overloaded virtual

### DIFF
--- a/main/configure.ac
+++ b/main/configure.ac
@@ -49,7 +49,7 @@ AC_CHECK_DEI80211MR(AC_MSG_NOTICE([Tracer for dei80211mr will be built]),
 		    AC_MSG_WARN([Tracer for dei80211mr will NOT be built]))
 
 
-NSMIRACLE_CPPFLAGS='-Wall -Werror'
+NSMIRACLE_CPPFLAGS='-Wall -Werror -Wno-overloaded-virtual'
 NSMIRACLE_CPPFLAGS="$NSMIRACLE_CPPFLAGS "'-I$(top_srcdir)/nsmiracle'
 NSMIRACLE_CPPFLAGS="$NSMIRACLE_CPPFLAGS "'-I$(top_srcdir)/ip'
 NSMIRACLE_CPPFLAGS="$NSMIRACLE_CPPFLAGS "'-I$(top_srcdir)/mphy'

--- a/main/nsmiracle/channel-module.cc
+++ b/main/nsmiracle/channel-module.cc
@@ -85,3 +85,8 @@ void ChannelModule::recv(Packet* p)
 {
 	recv(p,(ChSAP*)0);
 }
+
+void ChannelModule::recv(Packet *p, int idSrc)
+{
+	recv(p,(ChSAP*)0);
+}

--- a/main/nsmiracle/channel-module.h
+++ b/main/nsmiracle/channel-module.h
@@ -92,6 +92,16 @@ class ChannelModule : public Module {
 		**/
 		virtual void recv(Packet* p);
 		/**
+		* Method that intefaces the basic <i>recv</i> method (with only packet as parameter) with the specific
+		* Channel Module <i>recv</i> method, which uses the <i>ChSAP</i> to have knowledges about the source
+		* 
+		* @param p pointer to the packet will be received
+		* @param idSrc unique id of the module that has sent the packet
+		* 
+		* @see ChSAP
+		**/
+		virtual void recv(Packet *p, int idSrc);
+		/**
 		* Abstract method used to receive packet from the module of the above layer, it gives also knowledges about
 		* the source through the instance of <i>ChSAP</i> which connected them
 		* 

--- a/main/nsmiracle/plugin.cc
+++ b/main/nsmiracle/plugin.cc
@@ -233,7 +233,7 @@ PlugIn::setStackId(int val)
 int
 PlugIn::getTag(char *buf, int size)
 {
-	if ((buf == 0) || (size <= 0) || (tag_ == 0)) {
+	if ((buf == 0) || (size <= 0) || (tag_[0] == 0)) {
 		return (-1);
 	}
 


### PR DESCRIPTION
fixed Plugin warning
fixed ChanModule overloaded virtual warning
added -Wno-overloaded-virtual to configure.ac to prevent NS-2.34 errors.
closes #15 